### PR TITLE
Corporation table fix corrected

### DIFF
--- a/issue4.sql
+++ b/issue4.sql
@@ -1,12 +1,12 @@
 --liquibase formatted sql
 
---changeset other.dev:20 labels:example-label context:example-context
+--changeset other.dev:22 labels:Issue4 Correction context:Issue4 - Corporation table correction
 --comment: example comment
 
 create table Corporation (
-    uid int primary key, --auto_increment not null,
+    uid serial primary key, --auto_increment not null,
     name varchar(50) not null,
-    timestamp date not null,
+    timestamp timestamp not null,
     valid_from date not null,
     valid_until date not null
 )


### PR DESCRIPTION
Corporation table created in Postgres DB (Crystal).
Notes: the error came from the changelog argument from liquibase.properties file.
In the local repository (QQMS local) we should have the liquibase.properties file. Given the fact that this file stores user & pass in clear, we have created a file called ".gitignore" that has the command "ignore liquibase.properties file". Thus, the "liquibase.properties" file won't be commited (push) to github, it will remain in local where is needed.
N.B Although we have set uid type serial - Corporation table, if we see the SQL generated source code in Crystal db the uid is set as integer!?!